### PR TITLE
Support loading apt-fast.conf from /usr/local/etc

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -161,10 +161,12 @@ VERBOSE_OUTPUT=
 _DOWNLOADER='aria2c --no-conf -c -j ${_MAXNUM} -x ${_MAXCONPERSRV} -s ${_SPLITCON} -i ${DLLIST} --min-split-size=${_MINSPLITSZ} --stream-piece-selector=${_PIECEALGO} --connect-timeout=600 --timeout=600 -m0 --header "Accept: */*"'
 
 # Load config file.
-CONFFILE="/etc/apt-fast.conf"
-if [ -e "$CONFFILE" ]; then
-    source "$CONFFILE"
-fi
+for Prefix in /etc /usr/local/etc; do
+    CONFFILE=${Prefix}/apt-fast.conf
+    if [ -e "$CONFFILE" ]; then
+        source "$CONFFILE"
+    fi
+done
 
 # no proxy as default
 ftp_proxy=


### PR DESCRIPTION
Having `apt-fast.conf` put in `/usr/local/etc` will make
 - `apt-fast` easier to be copied around docker images by simply emitting `COPY --from=apt-fast /usr/local/ /usr/local/`